### PR TITLE
[OD-1072] Add a link to the harvest page in the account masthead

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,9 +190,7 @@ If you want to send Error-Mails when a Harvest-Job fails, you can set it up in p
 
     ckan.harvest.status_mail.errored = True
 
-The receiver(s) of the error-mails are configured in production.ini:
-
-    email_to = admin@your-portal.org, error-mails@your-portal.org
+That way, all CKAN-Users who are declared as Admins will receive the Error-Mails at their configured E-Mail-Address.
 
 If you don't specify this setting, the default will be False.
 

--- a/README.rst
+++ b/README.rst
@@ -95,11 +95,11 @@ Run the following command to create the necessary tables in the database (ensuri
 
     (pyenv) $ paster --plugin=ckanext-harvest harvester initdb --config=/etc/ckan/default/production.ini
 
-Finally, restart CKAN to have the changes take affect:
+Finally, restart CKAN to have the changes take effect::
 
     sudo service apache2 restart
 
-After installation, the harvest source listing should be available under /harvest, eg:
+After installation, the harvest source listing should be available under /harvest, eg::
 
     http://localhost/harvest
 
@@ -113,17 +113,17 @@ Database logger configuration(optional)
 
      ckan.harvest.log_scope = 0
 
- * -1 - Do not log in the database - DEFAULT
- *  0 - Log everything
- *  1 - model, logic.action, logic.validators, harvesters
- *  2 - model, logic.action, logic.validators
- *  3 - model, logic.action
- *  4 - logic.action
- *  5 - model
- *  6 - plugin
- *  7 - harvesters
+   * -1 - Do not log in the database - DEFAULT
+   *  0 - Log everything
+   *  1 - model, logic.action, logic.validators, harvesters
+   *  2 - model, logic.action, logic.validators
+   *  3 - model, logic.action
+   *  4 - logic.action
+   *  5 - model
+   *  6 - plugin
+   *  7 - harvesters
 
-2. Setup time frame(in days) for the clean-up mechanism with the following config parameter (in the `[app:main]` section)::
+2. Setup time frame (in days) for the clean-up mechanism with the following config parameter (in the `[app:main]` section)::
 
      ckan.harvest.log_timeframe = 10
 
@@ -138,7 +138,7 @@ Database logger configuration(optional)
 
 **API Usage**
 
-You can access CKAN harvest logs via the API:
+You can access CKAN harvest logs via the API::
 
     $ curl {ckan_url}/api/3/action/harvest_log_list
 
@@ -146,13 +146,13 @@ Replace {ckan_url} with the url from your CKAN instance.
 
 Allowed parameters are:
 
-    * level (filter log records by level)
+* ``level`` (filter log records by level)
 
-    * limit (used for pagination)
+* ``limit`` (used for pagination)
 
-    * offset (used for pagination)
+* ``offset`` (used for pagination)
 
-e.g. Fetch all logs with log level INFO:
+e.g. Fetch all logs with log level INFO::
 
     $ curl {ckan_url}/api/3/action/harvest_log_list?level=info
 
@@ -563,7 +563,7 @@ Here you can also find other examples of custom harvesters:
 Running the harvest jobs
 ========================
 
-There are two ways to run a harvest::
+There are two ways to run a harvest:
 
     1. ``harvester run_test`` for the command-line, suitable for testing
     2. ``harvester run`` used by the Web UI and scheduled runs

--- a/README.rst
+++ b/README.rst
@@ -183,6 +183,20 @@ or
 If you don't specify this setting, the default will be number-sequence.
 
 
+Send error mails when harvesting fails (optional)
+================================================
+
+If you want to send Error-Mails when a Harvest-Job fails, you can set it up in production.ini:
+
+    ckan.harvest.status_mail.errored = True
+
+The receiver(s) of the error-mails are configured in production.ini:
+
+    email_to = admin@your-portal.org, error-mails@your-portal.org
+
+If you don't specify this setting, the default will be False.
+
+
 Command line interface
 ======================
 

--- a/README.rst
+++ b/README.rst
@@ -553,7 +553,7 @@ following methods::
 See the CKAN harvester for an example of how to implement the harvesting
 interface:
 
- ckanext-harvest/ckanext/harvest/harvesters/ckanharvester.py
+* ckanext-harvest/ckanext/harvest/harvesters/ckanharvester.py
 
 Here you can also find other examples of custom harvesters:
 
@@ -565,8 +565,8 @@ Running the harvest jobs
 
 There are two ways to run a harvest:
 
-    1. ``harvester run_test`` for the command-line, suitable for testing
-    2. ``harvester run`` used by the Web UI and scheduled runs
+1. ``harvester run_test`` for the command-line, suitable for testing
+2. ``harvester run`` used by the Web UI and scheduled runs
 
 harvester run_test
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -184,13 +184,13 @@ If you don't specify this setting, the default will be number-sequence.
 
 
 Send error mails when harvesting fails (optional)
-================================================
+=================================================
 
-If you want to send Error-Mails when a Harvest-Job fails, you can set it up in production.ini:
+If you want to send and email when a Harvest Job fails, you can set the following configuration option in the ini file:
 
     ckan.harvest.status_mail.errored = True
 
-That way, all CKAN-Users who are declared as Admins will receive the Error-Mails at their configured E-Mail-Address.
+That way, all CKAN Users who are declared as Sysadmins will receive the Error emails at their configured email address.
 
 If you don't specify this setting, the default will be False.
 

--- a/README.rst
+++ b/README.rst
@@ -166,6 +166,22 @@ e.g. Fetch all logs with log level INFO:
     }
 
 
+Dataset name generation configuration (optional)
+================================================
+
+If the dataset name is created based on the title, duplicate names may occur.
+To avoid this, a suffix is appended to the name if it already exists.
+
+You can configure the default behaviour in your production.ini:
+
+    ckanext.harvest.default_dataset_name_append = number-sequence
+
+or
+
+    ckanext.harvest.default_dataset_name_append = random-hex
+
+If you don't specify this setting, the default will be number-sequence.
+
 
 Command line interface
 ======================

--- a/README.rst
+++ b/README.rst
@@ -785,7 +785,7 @@ following steps with the one you are using.
 Tests
 =====
 
-You can run the tests like this:
+You can run the tests like this::
 
     cd ckanext-harvest
     nosetests --reset-db --ckan --with-pylons=test-core.ini ckanext/harvest/tests
@@ -797,6 +797,7 @@ Here are some common errors and solutions:
 
 * ``(ProgrammingError) relation "harvest_object_extra" does not exist``
   The database has got into in a bad state. Run the tests again but *without* the ``--reset-db`` parameter.
+  Alternatively it's because you forgot to use the ``--ckan`` parameter.
 
 * ``(OperationalError) near "SET": syntax error``
   You are testing with SQLite as the database, but the CKAN Harvester needs PostgreSQL. Specify test-core.ini instead of test.ini.

--- a/ckanext/harvest/commands/harvester.py
+++ b/ckanext/harvest/commands/harvester.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 from pprint import pprint
 
@@ -6,6 +8,7 @@ from ckan.logic import get_action, ValidationError
 from ckan.plugins import toolkit
 
 from ckan.lib.cli import CkanCommand
+
 
 class Harvester(CkanCommand):
     '''Harvests remotely mastered metadata
@@ -114,9 +117,9 @@ class Harvester(CkanCommand):
     max_args = 9
     min_args = 0
 
-    def __init__(self,name):
+    def __init__(self, name):
 
-        super(Harvester,self).__init__(name)
+        super(Harvester, self).__init__(name)
 
         self.parser.add_option('-j', '--no-join-datasets', dest='no_join_datasets',
             action='store_true', default=False, help='Do not join harvest objects to existing datasets')
@@ -140,11 +143,10 @@ class Harvester(CkanCommand):
 
         # We'll need a sysadmin user to perform most of the actions
         # We will use the sysadmin site user (named as the site_id)
-        context = {'model':model,'session':model.Session,'ignore_auth':True}
-        self.admin_user = get_action('get_site_user')(context,{})
+        context = {'model': model, 'session': model.Session, 'ignore_auth': True}
+        self.admin_user = get_action('get_site_user')(context, {})
 
-
-        print ''
+        print('')
 
         if len(self.args) == 0:
             self.parser.print_usage()
@@ -206,7 +208,7 @@ class Harvester(CkanCommand):
         elif cmd == 'clean_harvest_log':
             self.clean_harvest_log()
         else:
-            print 'Command %s not recognized' % cmd
+            print('Command {0} not recognized'.format(cmd))
 
     def _load_config(self):
         super(Harvester, self)._load_config()
@@ -215,24 +217,24 @@ class Harvester(CkanCommand):
         from ckanext.harvest.model import setup as db_setup
         db_setup()
 
-        print 'DB tables created'
+        print('DB tables created')
 
     def create_harvest_source(self):
 
         if len(self.args) >= 2:
             name = unicode(self.args[1])
         else:
-            print 'Please provide a source name'
+            print('Please provide a source name')
             sys.exit(1)
         if len(self.args) >= 3:
             url = unicode(self.args[2])
         else:
-            print 'Please provide a source URL'
+            print('Please provide a source URL')
             sys.exit(1)
         if len(self.args) >= 4:
             type = unicode(self.args[3])
         else:
-            print 'Please provide a source type'
+            print('Please provide a source type')
             sys.exit(1)
 
         if len(self.args) >= 5:
@@ -265,34 +267,34 @@ class Harvester(CkanCommand):
                     'url': url,
                     'source_type': type,
                     'title': title,
-                    'active':active,
+                    'active': active,
                     'owner_org': owner_org,
                     'frequency': frequency,
                     'config': config,
                     }
 
             context = {
-                'model':model,
-                'session':model.Session,
+                'model': model,
+                'session': model.Session,
                 'user': self.admin_user['name'],
                 'ignore_auth': True,
             }
-            source = get_action('harvest_source_create')(context,data_dict)
-            print 'Created new harvest source:'
+            source = get_action('harvest_source_create')(context, data_dict)
+            print('Created new harvest source:')
             self.print_harvest_source(source)
 
-            sources = get_action('harvest_source_list')(context,{})
+            sources = get_action('harvest_source_list')(context, {})
             self.print_there_are('harvest source', sources)
 
             # Create a harvest job for the new source if not regular job.
             if not data_dict['frequency']:
                 get_action('harvest_job_create')(
                     context, {'source_id': source['id'], 'run': True})
-                print 'A new Harvest Job for this source has also been created'
+                print('A new Harvest Job for this source has also been created')
 
-        except ValidationError,e:
-           print 'An error occurred:'
-           print str(e.error_dict)
+        except ValidationError as e:
+           print('An error occurred:')
+           print(str(e.error_dict))
            raise e
 
     def clear_harvest_source_history(self):
@@ -306,16 +308,16 @@ class Harvester(CkanCommand):
             'session': model.Session
         }
         if source_id is not None:
-            get_action('harvest_source_job_history_clear')(context,{'id':source_id})
-            print 'Cleared job history of harvest source: %s' % source_id
+            get_action('harvest_source_job_history_clear')(context, {'id': source_id})
+            print('Cleared job history of harvest source: {0}'.format(source_id))
         else:
             '''
             Purge queues, because we clean all harvest jobs and
             objects in the database.
             '''
             self.purge_queues()
-            cleared_sources_dicts = get_action('harvest_sources_job_history_clear')(context,{})
-            print 'Cleared job history for all harvest sources: %s source(s)' % len(cleared_sources_dicts)
+            cleared_sources_dicts = get_action('harvest_sources_job_history_clear')(context, {})
+            print('Cleared job history for all harvest sources: {0} source(s)'.format(len(cleared_sources_dicts)))
 
 
     def show_harvest_source(self):
@@ -323,7 +325,7 @@ class Harvester(CkanCommand):
         if len(self.args) >= 2:
             source_id_or_name = unicode(self.args[1])
         else:
-            print 'Please provide a source name'
+            print('Please provide a source name')
             sys.exit(1)
         context = {'model': model, 'session': model.Session,
                    'user': self.admin_user['name']}
@@ -335,38 +337,38 @@ class Harvester(CkanCommand):
         if len(self.args) >= 2:
             source_id_or_name = unicode(self.args[1])
         else:
-            print 'Please provide a source id'
+            print('Please provide a source id')
             sys.exit(1)
         context = {'model': model, 'session': model.Session,
                    'user': self.admin_user['name']}
         source = get_action('harvest_source_show')(
             context, {'id': source_id_or_name})
         get_action('harvest_source_delete')(context, {'id': source['id']})
-        print 'Removed harvest source: %s' % source_id_or_name
+        print('Removed harvest source: {0}'.format(source_id_or_name))
 
     def clear_harvest_source(self):
         if len(self.args) >= 2:
             source_id_or_name = unicode(self.args[1])
         else:
-            print 'Please provide a source id'
+            print('Please provide a source id')
             sys.exit(1)
         context = {'model': model, 'session': model.Session,
                    'user': self.admin_user['name']}
         source = get_action('harvest_source_show')(
             context, {'id': source_id_or_name})
         get_action('harvest_source_clear')(context, {'id': source['id']})
-        print 'Cleared harvest source: %s' % source_id_or_name
+        print('Cleared harvest source: {0}'.format(source_id_or_name))
 
     def list_harvest_sources(self):
         if len(self.args) >= 2 and self.args[1] == 'all':
             data_dict = {}
             what = 'harvest source'
         else:
-            data_dict = {'only_active':True}
+            data_dict = {'only_active': True}
             what = 'active harvest source'
 
-        context = {'model': model,'session':model.Session, 'user': self.admin_user['name']}
-        sources = get_action('harvest_source_list')(context,data_dict)
+        context = {'model': model, 'session': model.Session, 'user': self.admin_user['name']}
+        sources = get_action('harvest_source_list')(context, data_dict)
         self.print_harvest_sources(sources)
         self.print_there_are(what=what, sequence=sources)
 
@@ -374,24 +376,24 @@ class Harvester(CkanCommand):
         if len(self.args) >= 2:
             source_id_or_name = unicode(self.args[1])
         else:
-            print 'Please provide a source id'
+            print('Please provide a source id')
             sys.exit(1)
         context = {'model': model, 'session': model.Session,
                    'user': self.admin_user['name']}
         source = get_action('harvest_source_show')(
             context, {'id': source_id_or_name})
 
-        context = {'model': model,'session':model.Session, 'user': self.admin_user['name']}
+        context = {'model': model, 'session': model.Session, 'user': self.admin_user['name']}
         job = get_action('harvest_job_create')(
             context, {'source_id': source['id'], 'run': True})
 
         self.print_harvest_job(job)
-        jobs = get_action('harvest_job_list')(context,{'status':u'New'})
+        jobs = get_action('harvest_job_list')(context, {'status': u'New'})
         self.print_there_are('harvest job', jobs, condition=u'New')
 
     def list_harvest_jobs(self):
-        context = {'model': model, 'user': self.admin_user['name'], 'session':model.Session}
-        jobs = get_action('harvest_job_list')(context,{})
+        context = {'model': model, 'user': self.admin_user['name'], 'session': model.Session}
+        jobs = get_action('harvest_job_list')(context, {})
 
         self.print_harvest_jobs(jobs)
         self.print_there_are(what='harvest job', sequence=jobs)
@@ -400,14 +402,14 @@ class Harvester(CkanCommand):
         if len(self.args) >= 2:
             job_or_source_id_or_name = unicode(self.args[1])
         else:
-            print 'Please provide a job id or source name/id'
+            print('Please provide a job id or source name/id')
             sys.exit(1)
 
         context = {'model': model, 'user': self.admin_user['name'],
                    'session': model.Session}
         job = get_action('harvest_job_abort')(
             context, {'id': job_or_source_id_or_name})
-        print 'Job status: {0}'.format(job['status'])
+        print('Job status: {0}'.format(job['status']))
 
     def run_harvester(self):
         context = {'model': model, 'user': self.admin_user['name'],
@@ -424,7 +426,7 @@ class Harvester(CkanCommand):
         if len(self.args) >= 2:
             source_id_or_name = unicode(self.args[1])
         else:
-            print 'Please provide a source id'
+            print('Please provide a source id')
             sys.exit(1)
         context = {'model': model, 'session': model.Session,
                    'user': self.admin_user['name']}
@@ -439,25 +441,25 @@ class Harvester(CkanCommand):
             running_jobs = get_action('harvest_job_list')(
                 context, {'source_id': source['id'], 'status': 'Running'})
             if running_jobs:
-                print '\nSource "%s" apparently has a "Running" job:\n%r' \
-                    % (source.get('name') or source['id'], running_jobs)
+                print('\nSource "{0}" apparently has a "Running" job:\n{1}'
+                    .format(source.get('name') or source['id'], running_jobs))
                 resp = raw_input('Abort it? (y/n)')
                 if not resp.lower().startswith('y'):
                     sys.exit(1)
                 job_dict = get_action('harvest_job_abort')(
                     context, {'source_id': source['id']})
             else:
-                print 'Reusing existing harvest job'
+                print('Reusing existing harvest job')
                 jobs = get_action('harvest_job_list')(
                     context, {'source_id': source['id'], 'status': 'New'})
                 assert len(jobs) == 1, \
-                    'Multiple "New" jobs for this source! %r' % jobs
+                    'Multiple "New" jobs for this source! {0}'.format(jobs)
                 job_dict = jobs[0]
         job_obj = HarvestJob.get(job_dict['id'])
 
         harvester = queue.get_harvester(source['source_type'])
         assert harvester, \
-            'No harvester found for type: %s' % source['source_type']
+            'No harvester found for type: {0}'.format(source['source_type'])
         lib.run_harvest_job(job_obj, harvester)
 
     def import_stage(self):
@@ -477,23 +479,23 @@ class Harvester(CkanCommand):
                    'join_datasets': not self.options.no_join_datasets,
                    'segments': self.options.segments}
 
-        objs_count = get_action('harvest_objects_import')(context,{
+        objs_count = get_action('harvest_objects_import')(context, {
                 'source_id': source_id,
                 'harvest_object_id': self.options.harvest_object_id,
                 'package_id': self.options.package_id,
                 'guid': self.options.guid,
                 })
 
-        print '%s objects reimported' % objs_count
+        print('{0} objects reimported'.format(objs_count))
 
     def create_harvest_job_all(self):
-        context = {'model': model, 'user': self.admin_user['name'], 'session':model.Session}
-        jobs = get_action('harvest_job_create_all')(context,{})
-        print 'Created %s new harvest jobs' % len(jobs)
+        context = {'model': model, 'user': self.admin_user['name'], 'session': model.Session}
+        jobs = get_action('harvest_job_create_all')(context, {})
+        print('Created {0} new harvest jobs'.format(len(jobs)))
 
     def reindex(self):
         context = {'model': model, 'user': self.admin_user['name']}
-        get_action('harvest_sources_reindex')(context,{})
+        get_action('harvest_sources_reindex')(context, {})
 
     def purge_queues(self):
         from ckanext.harvest.queue import purge_queues
@@ -501,53 +503,53 @@ class Harvester(CkanCommand):
 
     def print_harvest_sources(self, sources):
         if sources:
-            print ''
+            print('')
         for source in sources:
             self.print_harvest_source(source)
 
     def print_harvest_source(self, source):
-        print 'Source id: %s' % source.get('id')
+        print('Source id: {0}'.format(source.get('id')))
         if 'name' in source:
             # 'name' is only there if the source comes from the Package
-            print '     name: %s' % source.get('name')
-        print '      url: %s' % source.get('url')
+            print('     name: {0}'.format(source.get('name')))
+        print('      url: {0}'.format(source.get('url')))
         # 'type' if source comes from HarvestSource, 'source_type' if it comes
         # from the Package
-        print '     type: %s' % (source.get('source_type') or
-                                 source.get('type'))
-        print '   active: %s' % (source.get('active',
-                                            source.get('state') == 'active'))
-        print 'frequency: %s' % source.get('frequency')
-        print '     jobs: %s' % source.get('status').get('job_count')
-        print ''
+        print('     type: {0}'.format(source.get('source_type') or
+                                 source.get('type')))
+        print('   active: {0}'.format(source.get('active',
+                                            source.get('state') == 'active')))
+        print('frequency: {0}'.format(source.get('frequency')))
+        print('     jobs: {0}'.format(source.get('status').get('job_count')))
+        print('')
 
     def print_harvest_jobs(self, jobs):
         if jobs:
-            print ''
+            print('')
         for job in jobs:
             self.print_harvest_job(job)
 
     def print_harvest_job(self, job):
-        print '       Job id: %s' % job.get('id')
-        print '       status: %s' % job.get('status')
-        print '       source: %s' % job.get('source_id')
-        print '      objects: %s' % len(job.get('objects', []))
+        print('       Job id: {0}'.format(job.get('id')))
+        print('       status: {0}'.format(job.get('status')))
+        print('       source: {0}'.format(job.get('source_id')))
+        print('      objects: {0}'.format(len(job.get('objects', []))))
 
-        print 'gather_errors: %s' % len(job.get('gather_errors', []))
+        print('gather_errors: {0}'.format(len(job.get('gather_errors', []))))
         for error in job.get('gather_errors', []):
-            print '               %s' % error['message']
+            print('               {0}'.format(error['message']))
 
-        print ''
+        print('')
 
     def print_there_are(self, what, sequence, condition=''):
         is_singular = self.is_singular(sequence)
-        print 'There %s %s %s%s%s' % (
+        print('There {0} {1} {2}{3}{4}'.format(
             is_singular and 'is' or 'are',
             len(sequence),
-            condition and ('%s ' % condition.lower()) or '',
+            condition and ('{0} '.format(condition.lower())) or '',
             what,
             not is_singular and 's' or '',
-        )
+        ))
 
     def is_singular(self, sequence):
         return len(sequence) == 1
@@ -556,10 +558,10 @@ class Harvester(CkanCommand):
         from datetime import datetime, timedelta
         from pylons import config
         from ckanext.harvest.model import clean_harvest_log
-        
+
         # Log time frame - in days
         log_timeframe = toolkit.asint(config.get('ckan.harvest.log_timeframe', 30))
         condition = datetime.utcnow() - timedelta(days=log_timeframe)
-        
+
         # Delete logs older then the given date
         clean_harvest_log(condition=condition)

--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -60,7 +60,7 @@ class HarvesterBase(SingletonPlugin):
 
     @classmethod
     def _gen_new_name(cls, title, existing_name=None,
-                      append_type='number-sequence'):
+                      append_type=None):
         '''
         Returns a 'name' for the dataset (URL friendly), based on the title.
 
@@ -79,11 +79,19 @@ class HarvesterBase(SingletonPlugin):
         :type append_type: string
         '''
 
+        # If append_type was given, use it. Otherwise, use the configured default.
+        # If nothing was given and no defaults were set, use 'number-sequence'.
+        if append_type:
+            append_type_param = append_type
+        else:
+            append_type_param = config.get('ckanext.harvest.default_dataset_name_append',
+                                           'number-sequence')
+
         ideal_name = munge_title_to_name(title)
         ideal_name = re.sub('-+', '-', ideal_name)  # collapse multiple dashes
         return cls._ensure_name_is_unique(ideal_name,
                                           existing_name=existing_name,
-                                          append_type=append_type)
+                                          append_type=append_type_param)
 
     @staticmethod
     def _ensure_name_is_unique(ideal_name, existing_name=None,

--- a/ckanext/harvest/helpers.py
+++ b/ckanext/harvest/helpers.py
@@ -89,12 +89,10 @@ def harvest_frequencies():
             for f in UPDATE_FREQUENCIES]
 
 def harvest_times():
-
     return [{'text': p.toolkit._(f), 'value': f}
             for f in UPDATE_TIMES]
 
 def harvest_default_time():
-
     default_time = datetime.datetime.now().strftime('%I:00 %p')
     return default_time
 

--- a/ckanext/harvest/helpers.py
+++ b/ckanext/harvest/helpers.py
@@ -1,11 +1,13 @@
 
+import datetime
+
 from pylons import request
 from ckan import logic
 from ckan import model
 import ckan.lib.helpers as h
 import ckan.plugins as p
 
-from ckanext.harvest.model import UPDATE_FREQUENCIES
+from ckanext.harvest.model import UPDATE_FREQUENCIES, UPDATE_TIMES
 from ckanext.harvest.plugin import DATASET_TYPE_NAME
 from ckanext.harvest.interfaces import IHarvester
 
@@ -85,6 +87,16 @@ def harvest_frequencies():
 
     return [{'text': p.toolkit._(f.title()), 'value': f}
             for f in UPDATE_FREQUENCIES]
+
+def harvest_times():
+
+    return [{'text': p.toolkit._(f), 'value': f}
+            for f in UPDATE_TIMES]
+
+def harvest_default_time():
+
+    default_time = datetime.datetime.now().strftime('%I:00 %p')
+    return default_time
 
 def link_for_harvest_object(id=None, guid=None, text=None):
 

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -24,12 +24,14 @@ from ckan.logic import NotFound, check_access
 from ckanext.harvest.plugin import DATASET_TYPE_NAME
 from ckanext.harvest.queue import get_gather_publisher, resubmit_jobs
 
-from ckanext.harvest.model import HarvestSource, HarvestJob, HarvestObject
+from ckanext.harvest.model import HarvestSource, HarvestJob, HarvestObject, HarvestObjectError, HarvestGatherError
 from ckanext.harvest.logic import HarvestJobExists
 from ckanext.harvest.logic.dictization import harvest_job_dictize
 
 from ckanext.harvest.logic.action.get import (
     harvest_source_show, harvest_job_list, _get_sources_for_user)
+
+import ckan.lib.mailer as mailer
 
 log = logging.getLogger(__name__)
 
@@ -549,6 +551,9 @@ def harvest_jobs_run(context, data_dict):
                     # status
                     get_action('harvest_source_reindex')(
                         context, {'id': job_obj.source.id})
+
+                    if toolkit.asbool(config.get('ckan.harvest.status_mail.errored')) and has_job_errors(context, job_obj):
+                        send_error_mail(context, job_obj)
                 else:
                     log.debug('Ongoing job:%s source:%s',
                               job['id'], job['source_id'])
@@ -557,6 +562,116 @@ def harvest_jobs_run(context, data_dict):
     resubmit_jobs()
 
     return []  # merely for backwards compatibility
+
+
+def has_job_errors(context, job_obj):
+    model = context['model']
+
+    harvest_object_error_count = model.Session.query(HarvestObjectError) \
+        .join(HarvestObject, HarvestObjectError.harvest_object_id == HarvestObject.harvest_job_id) \
+        .filter(HarvestObject.harvest_job_id == job_obj.id) \
+        .count()
+
+    harvest_gather_error_count = model.Session.query(HarvestGatherError) \
+        .filter(HarvestGatherError.harvest_job_id == job_obj.id) \
+        .count()
+
+    # if no error occurred we do not create the error-mail
+    if harvest_object_error_count == 0 and harvest_gather_error_count == 0:
+        return False
+
+    return True
+
+
+def send_error_mail(context, job_obj):
+    model = context['model']
+
+    for row in model.Session\
+            .query(model.Package)\
+            .filter(model.Package.id == job_obj.source.id):
+        pkg = row.as_dict()
+        harvest_name = str(pkg['name'])
+
+    ckan_site_url = config.get('ckan.site_url')
+    job_url = ckan_site_url + '/harvest/' + harvest_name + '/job/' + job_obj.id
+
+    msg = toolkit._('This is a failure-notification of the latest harvest job ({0}) set-up in {1}.').format(job_url, ckan_site_url)
+    msg += '\n\n'
+
+    for org, job in model.Session\
+            .query(model.Group, HarvestSource)\
+            .outerjoin(model.Member, model.Group) \
+            .join(HarvestSource, HarvestSource.id == model.Member.table_id) \
+            .filter(model.Member.table_id == job_obj.source.id):
+
+        if org:
+            org_dict = org.as_dict()
+            msg += toolkit._('Organization: {0}').format(org_dict['title'])
+            msg += '\n\n'
+
+        job_dict = job.as_dict()
+        msg += toolkit._('Harvest Job Title: {0}').format(job_dict['title'])
+        msg += '\n\n'
+
+    msg += toolkit._('Date of Harvest: {0}').format(str(job_obj.created))
+    msg += ' UTC\n\n'
+
+    out = {
+        'last_job': None,
+    }
+
+    out['last_job'] = harvest_job_dictize(job_obj, context)
+
+    msg += toolkit._('Records in Error: {0}').format(str(out['last_job']['stats'].get('errored', 0)))
+    msg += '\n'
+
+    obj_error = ''
+    job_error = ''
+
+
+    for harvest_object_error in model.Session.query(HarvestObjectError) \
+            .join(HarvestObject, HarvestObjectError.harvest_object_id == HarvestObject.harvest_job_id) \
+            .filter(HarvestObject.harvest_job_id == job_obj.id).limit(20).all():
+        error_dict = harvest_object_error.as_dict()
+        obj_error += error_dict['msg'] + '\n'
+
+    for harvest_gather_error in model.Session.query(HarvestGatherError) \
+        .filter(HarvestGatherError.harvest_job_id == job_obj.id):
+        harvest_gather_error_dict = harvest_gather_error.as_dict()
+        job_error += harvest_gather_error_dict['message'] + '\n'
+
+    if (obj_error != '' or job_error != ''):
+        msg += toolkit._('Error Summary')
+        msg += '\n\n'
+
+    if (obj_error != ''):
+        msg += toolkit._('Document Error')
+        msg += '\n' + obj_error + '\n\n'
+
+    if (job_error != ''):
+        msg += toolkit._('Job Errors')
+        msg += '\n' + job_error + '\n\n'
+
+    if obj_error or job_error:
+        msg += '\n--\n'
+        msg += toolkit._('You are receiving this email because you are currently set-up as Administrator for {0}. Please do not reply to this email as it was sent from a non-monitored address.').format(config.get('ckan.site_title'))
+
+        # get recipients
+        email_recipients = config.get('email_to').split(',')
+        emails = {}
+
+        for recipient in email_recipients:
+            email = {'recipient_name': recipient,
+                      'recipient_email': recipient,
+                      'subject': config.get('ckan.site_title') + ' - Harvesting Job - Error Notification',
+                      'body': msg}
+
+            log.debug(msg)
+
+            try:
+                mailer.mail_recipient(**email)
+            except:
+                log.error('Sending Harvest-Notification-Mail failed. Message: ' + msg)
 
 
 def harvest_send_job_to_gather_queue(context, data_dict):

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -556,10 +556,7 @@ def harvest_jobs_run(context, data_dict):
                     status = get_action('harvest_source_show_status')(context, {'id': job_obj.source.id})
 
                     if toolkit.asbool(config.get('ckan.harvest.status_mail.errored')) and (status['last_job']['stats']['errored']):
-                        try:
-                            send_error_mail(context, job_obj.source.id, status)
-                        except mailer.MailerException:
-                            pass
+                        send_error_mail(context, job_obj.source.id, status)
                 else:
                     log.debug('Ongoing job:%s source:%s',
                               job['id'], job['source_id'])
@@ -637,15 +634,11 @@ def send_error_mail(context, source_id, status):
 
             try:
                 mailer.mail_recipient(**email)
-                return True
             except mailer.MailerException:
                 log.error('Sending Harvest-Notification-Mail failed. Message: ' + msg)
-                raise mailer.MailerException
             except Exception as e:
                 log.error(e)
                 raise
-
-    return False
 
 
 def harvest_send_job_to_gather_queue(context, data_dict):

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -621,15 +621,16 @@ def send_error_mail(context, source_id, status):
         msg += '\n--\n'
         msg += toolkit._('You are receiving this email because you are currently set-up as Administrator for {0}. Please do not reply to this email as it was sent from a non-monitored address.').format(config.get('ckan.site_title'))
 
-        # get recipients
-        email_recipients = config.get('email_to').split(',')
-        emails = {}
+        model = context['model']
 
-        for recipient in email_recipients:
+        sysadmins = model.Session.query(model.User).filter(model.User.sysadmin == True).all()
+
+        # for recipient in email_recipients:
+        for recipient in sysadmins:
             email = {'recipient_name': recipient,
-                      'recipient_email': recipient,
-                      'subject': config.get('ckan.site_title') + ' - Harvesting Job - Error Notification',
-                      'body': msg}
+                     'recipient_email': recipient,
+                     'subject': config.get('ckan.site_title') + ' - Harvesting Job - Error Notification',
+                     'body': msg}
 
             log.debug(msg)
 

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -450,8 +450,7 @@ def _calculate_next_run(frequency, time):
     if time and frequency != 'ALWAYS':
         t = datetime.datetime.strptime(time, '%I:%M %p')
         set_hour = int(t.strftime("%H"))
-        set_minute = int(t.strftime("%M"))
-        now = now.replace(hour=set_hour, minute=set_minute, second=0, microsecond=0)
+        now = now.replace(hour=set_hour, minute=0, second=0, microsecond=0)
 
     if frequency == 'ALWAYS':
         return now

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -444,9 +444,15 @@ def harvest_objects_import(context, data_dict):
     return last_objects_count
 
 
-def _calculate_next_run(frequency):
+def _calculate_next_run(frequency, time):
 
     now = datetime.datetime.utcnow()
+    if time and frequency != 'ALWAYS':
+        t = datetime.datetime.strptime(time, '%I:%M %p')
+        set_hour = int(t.strftime("%H"))
+        set_minute = int(t.strftime("%M"))
+        now = now.replace(hour=set_hour, minute=set_minute, second=0, microsecond=0)
+
     if frequency == 'ALWAYS':
         return now
     if frequency == 'WEEKLY':
@@ -482,7 +488,7 @@ def _make_scheduled_jobs(context, data_dict):
         except HarvestJobExists:
             log.info('Trying to rerun job for %s skipping', source.id)
 
-        source.next_run = _calculate_next_run(source.frequency)
+        source.next_run = _calculate_next_run(source.frequency, source.time)
         source.save()
 
 

--- a/ckanext/harvest/logic/schema.py
+++ b/ckanext/harvest/logic/schema.py
@@ -42,6 +42,7 @@ def harvest_source_schema():
         'private': [ignore_missing, boolean_validator],
         'organization': [ignore_missing],
         'frequency': [ignore_missing, unicode, harvest_source_frequency_exists, convert_to_extras],
+        'time': [ignore_missing, convert_to_extras],
         'state': [ignore_missing],
         'config': [ignore_missing, harvest_source_config_validator, convert_to_extras],
         'extras': default_extras_schema(),
@@ -81,6 +82,7 @@ def harvest_source_show_package_schema():
     schema.update({
         'source_type': [convert_from_extras, ignore_missing],
         'frequency': [convert_from_extras, ignore_missing],
+        'time': [convert_from_extras, ignore_missing],
         'config': [convert_from_extras, harvest_source_convert_from_config, ignore_missing],
         'metadata_created': [],
         'metadata_modified': [],

--- a/ckanext/harvest/model/__init__.py
+++ b/ckanext/harvest/model/__init__.py
@@ -512,8 +512,8 @@ def migrate_v4():
     conn = Session.connection()
 
     statement =  """
-ALTER TABLE harvest_source
-	ADD COLUMN time text;
+    ALTER TABLE harvest_source
+    ADD COLUMN time text;
     """
     conn.execute(statement)
     Session.commit()

--- a/ckanext/harvest/model/__init__.py
+++ b/ckanext/harvest/model/__init__.py
@@ -81,6 +81,9 @@ def setup():
         if not 'frequency' in column_names:
             log.debug('Harvest tables need to be updated')
             migrate_v3()
+        if not 'time' in column_names:
+            log.debug('Harvest tables need to be updated')
+            migrate_v4()
 
         # Check if this instance has harvest source datasets
         source_ids = Session.query(HarvestSource.id).filter_by(active=True).all()
@@ -502,6 +505,20 @@ ALTER TABLE harvest_object_error
     conn.execute(statement)
     Session.commit()
     log.info('Harvest tables migrated to v3')
+
+
+def migrate_v4():
+    log.debug('Migrating harvest tables to v4. This may take a while...')
+    conn = Session.connection()
+
+    statement =  """
+ALTER TABLE harvest_source
+	ADD COLUMN time text;
+    """
+    conn.execute(statement)
+    Session.commit()
+    log.info('Harvest tables migrated to v4')
+
 
 class PackageIdHarvestSourceIdMismatch(Exception):
     """

--- a/ckanext/harvest/model/__init__.py
+++ b/ckanext/harvest/model/__init__.py
@@ -22,6 +22,7 @@ from ckan.model.package import Package
 from ckan.lib.munge import munge_title_to_name
 
 UPDATE_FREQUENCIES = ['MANUAL','MONTHLY','WEEKLY','BIWEEKLY','DAILY', 'ALWAYS']
+UPDATE_TIMES = [datetime.time(i).strftime('%I:%M %p') for i in range(24)]
 
 log = logging.getLogger(__name__)
 
@@ -253,6 +254,7 @@ def define_harvester_tables():
         Column('user_id', types.UnicodeText, default=u''),
         Column('publisher_id', types.UnicodeText, default=u''),
         Column('frequency', types.UnicodeText, default=u'MANUAL'),
+        Column('time', types.UnicodeText, default=u''),
         Column('next_run', types.DateTime),
     )
     # Was harvesting_job

--- a/ckanext/harvest/plugin.py
+++ b/ckanext/harvest/plugin.py
@@ -291,6 +291,8 @@ class Harvest(p.SingletonPlugin, DefaultDatasetForm, DefaultTranslation):
                 'harvesters_info': harvest_helpers.harvesters_info,
                 'harvester_types': harvest_helpers.harvester_types,
                 'harvest_frequencies': harvest_helpers.harvest_frequencies,
+                'harvest_times': harvest_helpers.harvest_times,
+                'harvest_default_time': harvest_helpers.harvest_default_time,
                 'link_for_harvest_object': harvest_helpers.link_for_harvest_object,
                 'harvest_source_extra_fields': harvest_helpers.harvest_source_extra_fields,
                 }
@@ -363,7 +365,7 @@ def _create_harvest_source_object(context, data_dict):
     source.type = data_dict['source_type']
 
     opt = ['active', 'title', 'description', 'user_id',
-           'publisher_id', 'config', 'frequency']
+           'publisher_id', 'config', 'frequency', 'time']
     for o in opt:
         if o in data_dict and data_dict[o] is not None:
             source.__setattr__(o,data_dict[o])
@@ -399,7 +401,7 @@ def _update_harvest_source_object(context, data_dict):
 
 
     fields = ['url', 'title', 'description', 'user_id',
-              'publisher_id', 'frequency']
+              'publisher_id', 'frequency', 'time']
     for f in fields:
         if f in data_dict and data_dict[f] is not None:
             if f == 'url':

--- a/ckanext/harvest/templates/header.html
+++ b/ckanext/harvest/templates/header.html
@@ -1,0 +1,12 @@
+{% ckan_extends %}
+
+{% block header_account_logged %}
+  {% if c.userobj.sysadmin %}
+    <li>
+      <a href="{{ h.url_for('/harvest') }}" title="{{ _('Harvest') }}">
+        <i class="fa fa-leaf icon-leaf"></i>
+      </a>
+    </li>
+  {% endif %}
+  {{ super() }}
+{% endblock %}

--- a/ckanext/harvest/templates/source/new_source_form.html
+++ b/ckanext/harvest/templates/source/new_source_form.html
@@ -41,6 +41,7 @@
   </div>
 
   {{ form.select('frequency', id='field-frequency', label=_('Update frequency'), options=h.harvest_frequencies(), selected=data.frequency, error=errors.frequency) }}
+  {{ form.select('time', id='field-time', label=_('Update time'), options=h.harvest_times(), selected=data.time or h.harvest_default_time(), error=errors.time) }}
 
   {% block extra_config %}
   {{ form.textarea('config', id='field-config', label=_('Configuration'), value=data.config, error=errors.config) }}

--- a/ckanext/harvest/tests/harvesters/mock_ckan.py
+++ b/ckanext/harvest/tests/harvesters/mock_ckan.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import json
 import re
 import copy
@@ -188,7 +190,7 @@ def serve(port=PORT):
 
     httpd = TestServer(("", PORT), MockCkanHandler)
 
-    print 'Serving test HTTP server at port', PORT
+    print('Serving test HTTP server at port {}'.format(PORT))
 
     httpd_thread = Thread(target=httpd.serve_forever)
     httpd_thread.setDaemon(True)

--- a/ckanext/harvest/tests/harvesters/test_base.py
+++ b/ckanext/harvest/tests/harvesters/test_base.py
@@ -3,6 +3,7 @@ import re
 from nose.tools import assert_equal, assert_in
 from ckanext.harvest import model as harvest_model
 from ckanext.harvest.harvesters.base import HarvesterBase, munge_tag
+from mock import patch
 try:
     from ckan.tests import helpers
     from ckan.tests import factories
@@ -15,8 +16,7 @@ _ensure_name_is_unique = HarvesterBase._ensure_name_is_unique
 
 
 class TestGenNewName(object):
-    @classmethod
-    def setup_class(cls):
+    def setup(self):
         helpers.reset_db()
         harvest_model.setup()
 
@@ -27,6 +27,40 @@ class TestGenNewName(object):
         assert_equal(
             HarvesterBase._gen_new_name('Trees and branches - survey.'),
             'trees-and-branches-survey')
+
+    @patch.dict('ckanext.harvest.harvesters.base.config',
+                {'ckanext.harvest.some_other_config': 'value'})
+    def test_without_config(self):
+        '''Tests if the number suffix is used when no config is set.'''
+        factories.Dataset(name='trees')
+        assert_equal(
+            HarvesterBase._gen_new_name('Trees'),
+            'trees1')
+
+    @patch.dict('ckanext.harvest.harvesters.base.config',
+                {'ckanext.harvest.default_dataset_name_append': 'number-sequence'})
+    def test_number_config(self):
+        factories.Dataset(name='trees')
+        assert_equal(
+            HarvesterBase._gen_new_name('Trees'),
+            'trees1')
+    
+    @patch.dict('ckanext.harvest.harvesters.base.config',
+                {'ckanext.harvest.default_dataset_name_append': 'random-hex'})
+    def test_random_config(self):
+        factories.Dataset(name='trees')
+        new_name =  HarvesterBase._gen_new_name('Trees')
+        
+        assert re.match('trees[\da-f]{5}', new_name)
+    
+    @patch.dict('ckanext.harvest.harvesters.base.config',
+                {'ckanext.harvest.default_dataset_name_append': 'random-hex'})
+    def test_config_override(self):
+        '''Tests if a parameter has precedence over a config value.'''
+        factories.Dataset(name='trees')
+        assert_equal(
+            HarvesterBase._gen_new_name('Trees', append_type='number-sequence'),
+            'trees1')
 
 
 class TestEnsureNameIsUnique(object):

--- a/ckanext/harvest/tests/test_action.py
+++ b/ckanext/harvest/tests/test_action.py
@@ -29,6 +29,10 @@ from ckan import model
 
 from ckanext.harvest.interfaces import IHarvester
 import ckanext.harvest.model as harvest_model
+from ckanext.harvest.model import HarvestGatherError, HarvestJob
+from ckanext.harvest.logic import HarvestJobExists
+from ckanext.harvest.logic.action.update import send_error_mail
+import ckan.lib.mailer as mailer
 
 
 def call_action_api(action, apikey=None, status=200, **kwargs):
@@ -559,7 +563,92 @@ class TestHarvestObject(unittest.TestCase):
         self.assertRaises(toolkit.ValidationError, harvest_object_create,
                           context, data_dict)
 
-          
+
+class TestHarvestErrorMail(unittest.TestCase):
+    @classmethod
+    def setup_class(cls):
+        reset_db()
+        harvest_model.setup()
+
+    def _create_harvest_source_and_job_if_not_existing(self):
+        site_user = toolkit.get_action('get_site_user')(
+            {'model': model, 'ignore_auth': True}, {})['name']
+
+        context = {
+            'user': site_user,
+            'model': model,
+            'session': model.Session,
+            'ignore_auth': True,
+        }
+        source_dict = {
+            'title': 'Test Source',
+            'name': 'test-source',
+            'url': 'basic_test',
+            'source_type': 'test',
+        }
+
+        try:
+            harvest_source = toolkit.get_action('harvest_source_create')(
+                context,
+                source_dict
+            )
+        except toolkit.ValidationError:
+            harvest_source = toolkit.get_action('harvest_source_show')(
+                context,
+                {'id': source_dict['name']}
+            )
+            pass
+
+        try:
+            job = toolkit.get_action('harvest_job_create')(context, {
+                'source_id': harvest_source['id'], 'run': True})
+        except HarvestJobExists:
+            job = toolkit.get_action('harvest_job_show')(context, {
+                'id': harvest_source['status']['last_job']['id']})
+            pass
+
+        toolkit.get_action('harvest_jobs_run')(context, {})
+        toolkit.get_action('harvest_source_reindex')(context, {'id': harvest_source['id']})
+        return context, harvest_source, job
+
+    def test_error_mail_not_sent(self):
+        context, harvest_source, job = self._create_harvest_source_and_job_if_not_existing()
+
+        status = toolkit.get_action('harvest_source_show_status')(context, {'id': harvest_source['id']})
+
+        error_mail_sent = send_error_mail(
+            context,
+            harvest_source['id'],
+            status
+        )
+        assert_equal(0, status['last_job']['stats']['errored'])
+        assert_equal(False, error_mail_sent)
+
+    def test_error_mail_sent(self):
+        context, harvest_source, job = self._create_harvest_source_and_job_if_not_existing()
+
+        # create a HarvestGatherError
+        job_model = HarvestJob.get(job['id'])
+        msg = 'System error - No harvester could be found for source type %s' % job_model.source.type
+        err = HarvestGatherError(message=msg, job=job_model)
+        err.save()
+
+        status = toolkit.get_action('harvest_source_show_status')(context, {'id': harvest_source['id']})
+
+        # if we receive a Mailer-Exception we mark this test as skipped
+        try:
+            error_mail_sent = send_error_mail(
+                context,
+                harvest_source['id'],
+                status
+            )
+        except mailer.MailerException:
+            raise SkipTest()
+
+        assert_equal(1, status['last_job']['stats']['errored'])
+        assert_equal(True, error_mail_sent)
+
+
 class TestHarvestDBLog(unittest.TestCase):
     @classmethod
     def setup_class(cls):

--- a/ckanext/harvest/tests/test_action.py
+++ b/ckanext/harvest/tests/test_action.py
@@ -564,11 +564,17 @@ class TestHarvestObject(unittest.TestCase):
                           context, data_dict)
 
 
-class TestHarvestErrorMail(unittest.TestCase):
+class TestHarvestErrorMail(FunctionalTestBase):
     @classmethod
     def setup_class(cls):
+        super(TestHarvestErrorMail, cls).setup_class()
         reset_db()
         harvest_model.setup()
+
+    @classmethod
+    def teardown_class(cls):
+        super(TestHarvestErrorMail, cls).teardown_class()
+        reset_db()
 
     def _create_harvest_source_and_job_if_not_existing(self):
         site_user = toolkit.get_action('get_site_user')(

--- a/setup.py
+++ b/setup.py
@@ -1,53 +1,51 @@
 from setuptools import setup, find_packages
-import sys, os
 
-version = '1.1.0'
+version = '1.1.1'
 
 setup(
-	name='ckanext-harvest',
-	version=version,
-	description="Harvesting interface plugin for CKAN",
-	long_description="""\
-	""",
-	classifiers=[], # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
-	keywords='',
-	author='CKAN',
-	author_email='ckan@okfn.org',
-	url='http://ckan.org/wiki/Extensions',
-	license='AGPL',
-	packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-	namespace_packages=['ckanext'],
-	include_package_data=True,
-	zip_safe=False,
-	install_requires=[
-	        # dependencies are specified in pip-requirements.txt
-	        # instead of here
-	],
-	tests_require=[
-		'nose',
-		'mock',
-	],
-	test_suite = 'nose.collector',
-	entry_points=\
-	"""
-    [ckan.plugins]
-	# Add plugins here, eg
-	harvest=ckanext.harvest.plugin:Harvest
-	ckan_harvester=ckanext.harvest.harvesters:CKANHarvester
-    [ckan.test_plugins]
-	test_harvester=ckanext.harvest.tests.test_queue:MockHarvester
-	test_harvester2=ckanext.harvest.tests.test_queue2:MockHarvester
-	test_action_harvester=ckanext.harvest.tests.test_action:MockHarvesterForActionTests
-	[paste.paster_command]
-	harvester = ckanext.harvest.commands.harvester:Harvester
-    [babel.extractors]
-    ckan = ckan.lib.extract:extract_ckan
-	""",
-        message_extractors={
-            'ckanext': [
-                ('**.py', 'python', None),
-                ('**.js', 'javascript', None),
-                ('**/templates/**.html', 'ckan', None),
-            ],
-        }
+    name='ckanext-harvest',
+    version=version,
+    description="Harvesting interface plugin for CKAN",
+    long_description="""\
+    """,
+    classifiers=[],
+    keywords='',
+    author='CKAN',
+    author_email='ckan@okfn.org',
+    url='https://github.com/ckan/ckanext-harvest',
+    license='AGPL',
+    packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
+    namespace_packages=['ckanext'],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=[
+            # dependencies are specified in pip-requirements.txt
+            # instead of here
+    ],
+    tests_require=[
+        'nose',
+        'mock',
+    ],
+    test_suite='nose.collector',
+    entry_points="""
+        [ckan.plugins]
+            # Add plugins here, eg
+            harvest=ckanext.harvest.plugin:Harvest
+            ckan_harvester=ckanext.harvest.harvesters:CKANHarvester
+        [ckan.test_plugins]
+            test_harvester=ckanext.harvest.tests.test_queue:MockHarvester
+            test_harvester2=ckanext.harvest.tests.test_queue2:MockHarvester
+            test_action_harvester=ckanext.harvest.tests.test_action:MockHarvesterForActionTests
+        [paste.paster_command]
+            harvester = ckanext.harvest.commands.harvester:Harvester
+        [babel.extractors]
+            ckan = ckan.lib.extract:extract_ckan
+    """,
+    message_extractors={
+        'ckanext': [
+            ('**.py', 'python', None),
+            ('**.js', 'javascript', None),
+            ('**/templates/**.html', 'ckan', None),
+        ],
+    }
 )


### PR DESCRIPTION
## [Ticket](https://opengovinc.atlassian.net/browse/OD-1072)

## Description
The current version of the master branch is between [1.1.0](https://github.com/OpenGov-OpenData/ckanext-harvest/tree/v1.1.0) and [1.1.1](https://github.com/OpenGov-OpenData/ckanext-harvest/tree/v1.1.1). This PR updates the harvester to version 1.1.1 and adds a link to the harvest page in the account masthead.

Version v1.1.1 of the harvester added a feature to email sysadmins if a harvest job fails and some improvements to the format of the code.

## Testing
- Install this PR
- Restart the supervisor service
- Check that the harvest link is in the header
- Check that harvest extension can still works as expected. The dcat extension should be able to harvest http://bostonopendata.boston.opendata.arcgis.com/data.json