### PR TITLE
[OD-1164] Fix nulls in persistance_key

### DIFF
--- a/ckanext/harvest/queue.py
+++ b/ckanext/harvest/queue.py
@@ -207,7 +207,7 @@ class RedisConsumer(object):
     def persistance_key(self, message):
         # If you change this, make sure to update the script in `queue_purge`
         message = json.loads(message)
-        return self.routing_key + ':' + message[self.message_key]
+        return str(self.routing_key) + ':' + str(message[self.message_key])
 
     def basic_ack(self, message):
         self.redis.delete(self.persistance_key(message))


### PR DESCRIPTION
## [Ticket](https://opengovinc.atlassian.net/browse/OD-1164)

## Description
The variables self.routing_key and message[self.message_key] are casted as strings in case one of them are null.

This fixes the following error:
```
  File "/usr/local/bin/paster", line 11, in <module>
    sys.exit(run())
  File "/usr/local/lib/python2.7/dist-packages/paste/script/command.py", line 102, in run
    invoke(command, command_name, options, args[1:])
  File "/usr/local/lib/python2.7/dist-packages/paste/script/command.py", line 141, in invoke
    exit_code = runner.run(args)
  File "/usr/local/lib/python2.7/dist-packages/paste/script/command.py", line 236, in run
    result = self.command()
  File "/src/ckanext-harvest/ckanext/harvest/commands/harvester.py", line 192, in command
    for method, header, body in consumer.consume(queue=get_fetch_queue_name()):
  File "/src/ckanext-harvest/ckanext/harvest/queue.py", line 203, in consume
    self.redis.set(self.persistance_key(body),
  File "/src/ckanext-harvest/ckanext/harvest/queue.py", line 210, in persistance_key
    return self.routing_key + ':' + message[self.message_key]
TypeError: cannot concatenate 'str' and 'NoneType' objects
```