### PR TITLE
[OD-1547] Display local harvest time and tooltip

### DIFF
--- a/ckanext/harvest/fanstatic_library/js/harvest.js
+++ b/ckanext/harvest/fanstatic_library/js/harvest.js
@@ -1,0 +1,18 @@
+"use strict";
+
+this.ckan.module('automatic-local-time', function (jQuery) {
+  return {
+    initialize: function () {
+      var browserLocale = window.navigator.userLanguage || window.navigator.language;
+
+      jQuery('.local-time').each(function() {
+        moment.locale(browserLocale);
+        var time = moment(jQuery(this).data('time'), "hh:mm A ZZ");
+        if (time.isValid()) {
+            jQuery(this).html(time.format("LT ([UTC]Z)"));
+        }
+        jQuery(this).show();
+      })
+    }
+  }
+})

--- a/ckanext/harvest/fanstatic_library/webassets.yml
+++ b/ckanext/harvest/fanstatic_library/webassets.yml
@@ -2,3 +2,8 @@ harvest_css:
   output: ckanext-harvest/%(version)s_harvest_css.css
   contents:
     - styles/harvest.css
+
+harvest_js:
+  output: ckanext-harvest/%(version)s_harvest_js.js
+  contents:
+    - js/harvest.js

--- a/ckanext/harvest/helpers.py
+++ b/ckanext/harvest/helpers.py
@@ -114,8 +114,8 @@ def harvest_frequencies():
 
 
 def harvest_times():
-    return [{'text': p.toolkit._(f), 'value': f}
-            for f in UPDATE_TIMES]
+    return [{'text': time, 'value': time}
+            for time in UPDATE_TIMES]
 
 
 def harvest_default_time():

--- a/ckanext/harvest/templates/harvest/snippets/harvest_asset.html
+++ b/ckanext/harvest/templates/harvest/snippets/harvest_asset.html
@@ -1,1 +1,2 @@
 {% asset 'ckanext-harvest/harvest_css' %}
+{% asset 'ckanext-harvest/harvest_js' %}

--- a/ckanext/harvest/templates/harvest/snippets/harvest_resource.html
+++ b/ckanext/harvest/templates/harvest/snippets/harvest_resource.html
@@ -1,1 +1,2 @@
 {% resource 'ckanext-harvest/styles/harvest.css' %}
+{% resource 'ckanext-harvest/js/harvest.js' %}

--- a/ckanext/harvest/templates/source/new_source_form.html
+++ b/ckanext/harvest/templates/source/new_source_form.html
@@ -44,7 +44,19 @@
   </div>
 
   {{ form.select('frequency', id='field-frequency', label=_('Update frequency'), options=h.harvest_frequencies(), selected=data.frequency, error=errors.frequency) }}
-  {{ form.select('time', id='field-time', label=_('Update time'), options=h.harvest_times(), selected=data.time or h.harvest_default_time(), error=errors.time) }}
+
+  <div class="control-group control-select">
+    <label class="control-label" for="field-time">{{ _('Update time') }}</label>
+    <div class="controls ">
+    <select id="field-time" name="time">
+      {% set selected = data.time or h.harvest_default_time() %}
+      {% for option in h.harvest_times() %}
+        <option value="{{ option.value }}" class="local-time" data-module="automatic-local-time" data-time="{{ option.text }} +0000" {% if option.value == selected %} selected{% endif %}>{{ option.text }}</option>
+      {% endfor %}
+    </select>
+    <i class="fa fa-question-circle icon-question-sign muted" title="Harvest times are stored in UTC format, daylight savings time changes will not apply" data-toggle="tooltip"></i>
+    </div>
+  </div>
 
   {% block extra_config %}
   {{ form.textarea('config', id='field-config', label=_('Configuration'), value=data.config, error=errors.config) }}


### PR DESCRIPTION
## Description
This PR displays a user's local time in the harvest times list.
Also add a tooltip to let users know the harvest times are stored in UTC format.

![Screen Shot 2021-03-31 at 6 21 27 PM](https://user-images.githubusercontent.com/4096633/113218672-ed853800-924d-11eb-8112-1c32e280bfa7.png)

## Test
- Install ckanext-harvest plugin and checkout PR
- View harvest edit page and confirm that times appear with local timezone