### PR TITLE
Fix js load order for ckan 2.9

### DIFF
--- a/ckanext/harvest/fanstatic_library/webassets.yml
+++ b/ckanext/harvest/fanstatic_library/webassets.yml
@@ -4,6 +4,10 @@ harvest_css:
     - styles/harvest.css
 
 harvest_js:
+  filters: rjsmin
   output: ckanext-harvest/%(version)s_harvest_js.js
+  extra:
+    preload:
+      - base/main
   contents:
     - js/harvest.js

--- a/ckanext/harvest/templates/source/new_source_form.html
+++ b/ckanext/harvest/templates/source/new_source_form.html
@@ -45,7 +45,7 @@
 
   {{ form.select('frequency', id='field-frequency', label=_('Update frequency'), options=h.harvest_frequencies(), selected=data.frequency, error=errors.frequency) }}
 
-  <div class="control-group control-select">
+  <div class="form-group control-group control-select">
     <label class="control-label" for="field-time">{{ _('Update time') }}</label>
     <div class="controls ">
     <select id="field-time" name="time">


### PR DESCRIPTION
## Description
This PR fixes the load order of harvest.js so that it loads after the ckan main js libraries.
Also adds the form-group class to the harvest time dropdown for better spacing in bootstrap 3.