### PR TITLE
Remove 'show_errors' from fq before search

### DIFF
--- a/ckanext/harvest/plugin/__init__.py
+++ b/ckanext/harvest/plugin/__init__.py
@@ -107,6 +107,10 @@ class Harvest(MixinPlugin, p.SingletonPlugin, DefaultDatasetForm, DefaultTransla
             fq = u"{0} -dataset_type:harvest".format(search_params.get('fq', ''))
             search_params.update({'fq': fq})
 
+        if '+dataset_type:harvest' in fq and 'show_errors:"true"' in fq:
+            fq = fq.replace('show_errors:"true"', '')
+            search_params.update({'fq': fq})
+
         return search_params
 
     def after_show(self, context, data_dict):


### PR DESCRIPTION
This PR fixes an issue with the feature to display job errors on the harvest source page.

## Background
To display the errors the url param `show_errors=true` is used.
However, this adds `show_errors` as part of the solr query meaning that no harvest sources will be returned.
To fix this issue we should remove `show_errors=true` from the `fq` search param if the search will be for the harvest page.