### PR TITLE
Randomize minute of next run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,10 +47,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install requirements
+    - name: Install requirements (Python 3)
+      if: ${{ matrix.ckan-version != '2.7' && matrix.ckan-version != '2.8' && matrix.ckan-version != '2.9-py2'}}
       run: |
         pip install -r pip-requirements.txt
         pip install -r dev-requirements.txt
+    - name: Install requirements (Python 2)
+      if: ${{ matrix.ckan-version == '2.7' || matrix.ckan-version == '2.8' || matrix.ckan-version == '2.9-py2'}}
+      run: |
+        pip install -r pip-requirements-py2.txt
+        pip install -r dev-requirements.txt
+    - name: Install requirements (common)
+      run: |
         pip install -e .
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini

--- a/ckanext/harvest/helpers.py
+++ b/ckanext/harvest/helpers.py
@@ -1,6 +1,6 @@
 
 import datetime
-
+from ckan import logic
 from ckan import model
 import ckan.lib.helpers as h
 import ckan.plugins as p
@@ -55,7 +55,7 @@ def package_list_for_source(source_id):
         if (harvest_source and owner_org in user_member_of_orgs):
             context['ignore_capacity_check'] = True
 
-    query = p.toolkit.get_action('package_search')(context, search_dict)
+    query = logic.get_action('package_search')(context, search_dict)
 
     base_url = h.url_for(
         '{0}_read'.format(DATASET_TYPE_NAME),
@@ -94,13 +94,13 @@ def package_count_for_source(source_id):
     fq = '+harvest_source_id:"{0}"'.format(source_id)
     search_dict = {'fq': fq}
     context = {'model': model, 'session': model.Session}
-    result = p.toolkit.get_action('package_search')(context, search_dict)
+    result = logic.get_action('package_search')(context, search_dict)
     return result.get('count', 0)
 
 
 def harvesters_info():
     context = {'model': model, 'user': p.toolkit.c.user or p.toolkit.c.author}
-    return p.toolkit.get_action('harvesters_info_show')(context, {})
+    return logic.get_action('harvesters_info_show')(context, {})
 
 
 def harvester_types():
@@ -132,7 +132,7 @@ def link_for_harvest_object(id=None, guid=None, text=None):
 
     if guid:
         context = {'model': model, 'user': p.toolkit.c.user or p.toolkit.c.author}
-        obj = p.toolkit.get_action('harvest_object_show')(context, {'id': guid, 'attr': 'guid'})
+        obj = logic.get_action('harvest_object_show')(context, {'id': guid, 'attr': 'guid'})
         id = obj.id
 
     url = h.url_for('harvest_object_show', id=id)

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -575,8 +575,7 @@ def _calculate_next_run(frequency, time):
         set_hour = int(t.strftime("%H"))
         now = now.replace(
             hour=set_hour,
-            minute=random.randint(0, 30),
-            second=random.randint(0, 59)
+            minute=random.randint(0, 5)
         )
 
     if frequency == 'ALWAYS':

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -6,6 +6,7 @@ import six
 
 import logging
 import datetime
+import random
 
 from ckantoolkit import config
 from sqlalchemy import and_, or_
@@ -572,7 +573,11 @@ def _calculate_next_run(frequency, time):
     if time and frequency != 'ALWAYS':
         t = datetime.datetime.strptime(time, '%I:%M %p')
         set_hour = int(t.strftime("%H"))
-        now = now.replace(hour=set_hour, minute=0, second=0, microsecond=0)
+        now = now.replace(
+            hour=set_hour,
+            minute=random.randint(0, 30),
+            second=random.randint(0, 59)
+        )
 
     if frequency == 'ALWAYS':
         return now

--- a/ckanext/harvest/model/__init__.py
+++ b/ckanext/harvest/model/__init__.py
@@ -18,7 +18,7 @@ from ckan.model.domain_object import DomainObject
 from ckan.model.package import Package
 
 
-UPDATE_FREQUENCIES = ['MANUAL', 'MONTHLY', 'WEEKLY', 'BIWEEKLY', 'DAILY', 'ALWAYS']
+UPDATE_FREQUENCIES = ['MANUAL', 'MONTHLY', 'BIWEEKLY', 'WEEKLY', 'DAILY', 'ALWAYS']
 UPDATE_TIMES = [datetime.time(i).strftime('%I:%M %p') for i in range(24)]
 
 log = logging.getLogger(__name__)

--- a/pip-requirements-py2.txt
+++ b/pip-requirements-py2.txt
@@ -1,0 +1,6 @@
+ckantoolkit>=0.0.7
+pika==1.1.0
+pyOpenSSL==18.0.0
+redis
+requests>=2.11.1
+six>=1.12.0


### PR DESCRIPTION
## Description
This PR modifies the timing of the next time a scheduled harvest job should run.
Instead of running on an exact hour (i.e. 10:00 am) it will run sometime within the first 5 mins of the scheduled time (i.e. 10:03 am).

This will reduce the chances of several harvest jobs running at the exact same moment and causing issues with requests in the gather queue.