### PR TITLE
Merge upstream master

### DIFF
--- a/ckanext/harvest/logic/action/get.py
+++ b/ckanext/harvest/logic/action/get.py
@@ -437,10 +437,11 @@ def harvest_get_notifications_recipients(context, data_dict):
     ).all()
 
     for sysadmin in sysadmins:
-        recipients.append({
-            'name': sysadmin.name,
-            'email': sysadmin.email
-        })
+        if sysadmin.email:
+            recipients.append({
+                'name': sysadmin.name,
+                'email': sysadmin.email
+            })
 
     # gather organization-admins
     if source.get('organization'):

--- a/ckanext/harvest/tests/harvesters/test_base.py
+++ b/ckanext/harvest/tests/harvesters/test_base.py
@@ -1,7 +1,11 @@
 import re
 
 import pytest
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
 
 from ckanext.harvest.harvesters.base import HarvesterBase, munge_tag
 from ckantoolkit.tests import factories

--- a/ckanext/harvest/tests/harvesters/test_ckanharvester.py
+++ b/ckanext/harvest/tests/harvesters/test_ckanharvester.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import
 import copy
 
 import json
-from mock import patch, MagicMock, Mock
+try:
+    from unittest.mock import patch, MagicMock, Mock
+except ImportError:
+    from mock import patch, MagicMock, Mock
 import pytest
 from requests.exceptions import HTTPError, RequestException
 

--- a/ckanext/harvest/tests/test_blueprint.py
+++ b/ckanext/harvest/tests/test_blueprint.py
@@ -16,10 +16,6 @@ def _assert_in_body(string, response):
 @pytest.mark.usefixtures('clean_db', 'clean_index', 'harvest_setup')
 class TestBlueprint():
 
-    def setup(self):
-        sysadmin = factories.Sysadmin()
-        self.extra_environ = {'REMOTE_USER': sysadmin['name'].encode('ascii')}
-
     def test_index_page_is_rendered(self, app):
 
         source1 = harvest_factories.HarvestSource()
@@ -33,8 +29,10 @@ class TestBlueprint():
     def test_new_form_is_rendered(self, app):
 
         url = url_for('harvest_new')
+        sysadmin = factories.Sysadmin()
+        env = {"REMOTE_USER": sysadmin['name'].encode('ascii')}
 
-        response = app.get(url, extra_environ=self.extra_environ)
+        response = app.get(url, extra_environ=env)
 
         _assert_in_body('<form id="source-new"', response)
 
@@ -43,8 +41,10 @@ class TestBlueprint():
         source = harvest_factories.HarvestSource()
 
         url = url_for('harvest_edit', id=source['id'])
+        sysadmin = factories.Sysadmin()
+        env = {"REMOTE_USER": sysadmin['name'].encode('ascii')}
 
-        response = app.get(url, extra_environ=self.extra_environ)
+        response = app.get(url, extra_environ=env)
 
         _assert_in_body('<form id="source-new"', response)
 
@@ -53,8 +53,10 @@ class TestBlueprint():
         source = harvest_factories.HarvestSource()
 
         url = url_for('harvest_read', id=source['name'])
+        sysadmin = factories.Sysadmin()
+        env = {"REMOTE_USER": sysadmin['name'].encode('ascii')}
 
-        response = app.get(url, extra_environ=self.extra_environ)
+        response = app.get(url, extra_environ=env)
 
         _assert_in_body(source['name'], response)
 
@@ -79,8 +81,10 @@ class TestBlueprint():
         source = harvest_factories.HarvestSource()
 
         url = url_for('harvest_about', id=source['name'])
+        sysadmin = factories.Sysadmin()
+        env = {"REMOTE_USER": sysadmin['name'].encode('ascii')}
 
-        response = app.get(url, extra_environ=self.extra_environ)
+        response = app.get(url, extra_environ=env)
 
         _assert_in_body(source['name'], response)
 
@@ -116,7 +120,9 @@ class TestBlueprint():
 
         url = url_for(
             'harvest_job_show', source=job['source_id'], id=job['id'])
+        sysadmin = factories.Sysadmin()
+        env = {"REMOTE_USER": sysadmin['name'].encode('ascii')}
 
-        response = app.get(url, extra_environ=self.extra_environ)
+        response = app.get(url, extra_environ=env)
 
         _assert_in_body(job['id'], response)

--- a/ckanext/harvest/tests/test_queue.py
+++ b/ckanext/harvest/tests/test_queue.py
@@ -1,5 +1,8 @@
 import pytest
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from ckanext.harvest.model import HarvestObject, HarvestObjectExtra
 from ckanext.harvest.interfaces import IHarvester

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ckantoolkit>=0.0.7
 pika>=1.1.0,<1.3.0
-pyOpenSSL==18.0.0
+pyOpenSSL>=21.0.0
 redis
 requests>=2.11.1
 six>=1.12.0


### PR DESCRIPTION
## Description
This PR merges recent commits from the upstream master of https://github.com/ckan/ckanext-harvest

An important change was the version bump of pyOpenSSL. This is needed to fix the following error:
```
   File "/__w/ckanext-harvest/ckanext-harvest/ckanext/harvest/harvesters/ckanharvester.py", line 7, in <module>
    from urllib3.contrib import pyopenssl
  File "/usr/lib/python3.9/site-packages/urllib3/contrib/pyopenssl.py", line 50, in <module>
    import OpenSSL.SSL
  File "/usr/lib/python3.9/site-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import crypto, SSL
  File "/usr/lib/python3.9/site-packages/OpenSSL/crypto.py", line 1550, in <module>
    class X509StoreFlags(object):
  File "/usr/lib/python3.9/site-packages/OpenSSL/crypto.py", line 1570, in X509StoreFlags
    CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'
```