### PR TITLE
Cast persistance_key as string to fix null issue

### DIFF
--- a/ckanext/harvest/queue.py
+++ b/ckanext/harvest/queue.py
@@ -283,7 +283,7 @@ class RedisConsumer(object):
     def persistance_key(self, message):
         # If you change this, make sure to update the script in `queue_purge`
         message = json.loads(message)
-        return self.routing_key + ':' + message[self.message_key]
+        return str(self.routing_key) + ':' + str(message[self.message_key])
 
     def basic_ack(self, message):
         self.redis.delete(self.persistance_key(message))


### PR DESCRIPTION
## Description
Cast persistance_key as string to fix null issue.
The variables `self.routing_key` and `message[self.message_key]` are casted as string in case one of them is null.