### PR TITLE
Use <button> element for delete harvest source

### DIFF
--- a/ckanext/harvest/templates/source/new_source_form.html
+++ b/ckanext/harvest/templates/source/new_source_form.html
@@ -108,10 +108,10 @@
         {% set locale_delete = h.dump_json({'content': _('This will flag the source as deleted but keep all its datasets and previous jobs. Are you sure you want to delete this harvest source?')}) %}
         {% set locale_clear = h.dump_json({'content': _('Warning: Apart from deleting this source, this command will remove all its datasets, as well as all previous job reports. Are you sure you want to continue?')}) %}
   <div class="dropdown btn-group">
-    <a href="#" class="btn btn-danger dropdown-toggle" data-bs-toggle="dropdown" data-toggle="dropdown">
+    <button class="btn btn-danger dropdown-toggle" data-bs-toggle="dropdown" data-toggle="dropdown">
       {{ _('Delete') }}
       <span class="caret"></span>
-    </a>
+    </button>
     <ul class="dropdown-menu">
       <li>
         <a href="{% url_for 'harvest_delete', id=data.name %}" data-module="confirm-action" data-module-i18n="{{ locale_delete }}">


### PR DESCRIPTION
## Description
This PR fixes an issue with the delete harvest source button in the harvest source edit page.
The issue is that it currently uses an anchor element with href set to "#" and depends on JS to display a dropdown menu for delete options.
Instead a button element should be used if the href attribute is not used and needs JS.

This also improves accessibility of screen readers.
