### PR TITLE
Support redis ssl

### DIFF
--- a/ckanext/harvest/queue.py
+++ b/ckanext/harvest/queue.py
@@ -73,6 +73,17 @@ def get_connection_redis():
             encoding='utf-8',
         )
     else:
+        if config.get('ckan.harvest.mq.enable_ssl', False):
+            return redis.Redis(
+                host=config.get('ckan.harvest.mq.hostname', HOSTNAME),
+                port=int(config.get('ckan.harvest.mq.port', REDIS_PORT)),
+                password=config.get('ckan.harvest.mq.password', None),
+                db=int(config.get('ckan.harvest.mq.redis_db', REDIS_DB)),
+                decode_responses=True,
+                encoding='utf-8',
+                ssl=True,
+                ssl_cert_reqs='none',
+            )
         return redis.Redis(
             host=config.get('ckan.harvest.mq.hostname', HOSTNAME),
             port=int(config.get('ckan.harvest.mq.port', REDIS_PORT)),

--- a/ckanext/harvest/tests/harvesters/test_ckanharvester.py
+++ b/ckanext/harvest/tests/harvesters/test_ckanharvester.py
@@ -49,7 +49,7 @@ class TestCkanHarvester(object):
         obj_ids = harvester.gather_stage(job)
 
         assert job.gather_errors == []
-        assert type(obj_ids) == list
+        assert isinstance(obj_ids, list)
         assert len(obj_ids) == len(mock_ckan.DATASETS)
         harvest_object = harvest_model.HarvestObject.get(obj_ids[0])
         assert harvest_object.guid == mock_ckan.DATASETS[0]['id']


### PR DESCRIPTION
Add support for using redis with SSL enabled.
https://redis.readthedocs.io/en/stable/examples/ssl_connection_examples.html#Connecting-to-a-Redis-instance-via-SSL.